### PR TITLE
Fix segfault during d.init() in NewDevice.

### DIFF
--- a/cryptsetup.go
+++ b/cryptsetup.go
@@ -24,6 +24,7 @@ func init() {
 // device to encrypt. It is the caller's responsibility to ensure that
 // `Close` gets called on the device (or a copy of the device).
 func NewDevice(name string) (d *Device, err error) {
+	d = new(Device)
 	err = d.init(name)
 	return
 }
@@ -93,7 +94,7 @@ func (d *Device) Benchmark(iv_size uint64, buffer_size uint64, pp Params) (enc f
 	return
 }
 
-// BenchmarkKdb runs the the library's internal benchmark code for the
+// BenchmarkKdf runs the the library's internal benchmark code for the
 // Key Deriviation Function. It returns the number hashes performed in
 // one second on the password with the given salt.
 //

--- a/cryptsetup_test.go
+++ b/cryptsetup_test.go
@@ -9,7 +9,7 @@ import (
 
 const luksSize = 1049600
 
-func freeme(d Device, f *os.File) {
+func freeme(d *Device, f *os.File) {
 	d.Close()
 	err := os.Remove(f.Name())
 	if err != nil {
@@ -21,7 +21,7 @@ func freeme(d Device, f *os.File) {
 	}
 }
 
-func makeDeviceSize(luksSize int64) (d Device, f *os.File, err error) {
+func makeDeviceSize(luksSize int64) (d *Device, f *os.File, err error) {
 	f, err = ioutil.TempFile("", "go-cryptsetup_testfile")
 	if err != nil {
 		return
@@ -42,7 +42,7 @@ func makeDeviceSize(luksSize int64) (d Device, f *os.File, err error) {
 	return
 }
 
-func makeDevice() (Device, *os.File, error) {
+func makeDevice() (*Device, *os.File, error) {
 	return makeDeviceSize(luksSize)
 }
 


### PR DESCRIPTION
The device struct was never actually allocated in `NewDevice()`, causing a segfault in the `init()`
method when it attempted to dereference the `cd` member.

I also edited some of the test helper functions slightly to get the tests to compile and
run properly. Some of the helper functions in the tests took in `Device` structs, but
`NewDevice()` returns a pointer.

After these edits, all tests now run successfully on my machine.